### PR TITLE
Add FUTO.MDNS Flake

### DIFF
--- a/alejandra.toml
+++ b/alejandra.toml
@@ -1,0 +1,1 @@
+indentation = "Tabs"

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+	description = "FUTO's MDNS library";
+
+	inputs = {
+		nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+	};
+
+	outputs = {
+		self,
+		nixpkgs,
+	}: let
+		system = "x86_64-linux";
+		pkgs = nixpkgs.legacyPackages.${system};
+
+		getArch = system: nix2Net."${system}";
+		nix2Net = {
+			x86_64-linux = "linux-x64";
+		};
+
+		sourceRepo =
+			pkgs.fetchFromGitHub {
+				owner = "futo-org";
+				repo = "FUTO.MDNS";
+				rev = "3c7ccbd2df32d454d7b06a0933d1944e9fbc48fa";
+				hash = "sha256-bgTac8IiJY6DZWLJWIK7k5kcf8XVtz8+8cipDYIg2hA=";
+			};
+	in {
+		packages.${system}.default = let
+		in
+			pkgs.buildDotnetModule {
+				name = "futo-mdns";
+
+				src = "${sourceRepo}/FUTO.MDNS";
+				pubDir = "./bin/Release/net8.0/${getArch system}/publish";
+
+				meta = {
+					description = "FUTO's MDNS library";
+				};
+			};
+	};
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,11 +12,6 @@
 		system = "x86_64-linux";
 		pkgs = nixpkgs.legacyPackages.${system};
 
-		getArch = system: nix2Net."${system}";
-		nix2Net = {
-			x86_64-linux = "linux-x64";
-		};
-
 		sourceRepo =
 			pkgs.fetchFromGitHub {
 				owner = "futo-org";
@@ -31,7 +26,7 @@
 				name = "futo-mdns";
 
 				src = "${sourceRepo}/FUTO.MDNS";
-				pubDir = "./bin/Release/net8.0/${getArch system}/publish";
+				dotnetInstallPath = "$out/lib";
 
 				meta = {
 					description = "FUTO's MDNS library";


### PR DESCRIPTION
I've written and tested a flake.nix for FUTO.MDNS

It appears to build FUTO.MDNS as Grayjay.ClientServer expects, but I can't be sure until I test it on `Grayjay.Desktop/Grayjay.ClientServer/flake.nix`. If someone with more knowledge of dotnet's intricacies (and `.csproj` files in partilcular, namely [Grayjay.ClientServer.csproj](https://github.com/futo-org/Grayjay.Desktop/blob/master/Grayjay.ClientServer/Grayjay.ClientServer.csproj)) could verify this, I would appreciate it very much.

You can replicate this build to your own satisfaction by running `nix build` from the repo's root or running `nix build github:danthony28/FUTO.MDNS/flake-futo-mdns` from pretty much anywhere and digging through the `result` symlink. My intentions are to use this derivation as-is in the way `dotnet build`, `dotnet publish`, etc. expect in the flake.nix for Grayjay.ClientServer; ideally straight from nixpkgs but it's just a flake for now.

I'll commit the lockfile once everything is verified to be working as dotnet expects on Grayjay.ClientServer (not just as I expect).

> [!NOTE]
> #### To the maintainers  
> I'll be following the "branch stacking" convention for these flakes, so it may be more convenient to merge a different branch, which should be mentioned below. I'll do my best to specifically comment when a branch _shouldn't_ be merged into `master` (this is usually because it will cause messy conflicts down the road).
> - This particular branch must be merged for https://github.com/danthony28/Grayjay.Desktop/tree/flake-grayjay-clientserver to be merged.
> - This branch cannot be merged until that same branch has a verified-working flake.nix
> - This branch should have a lockfile committed before merging.

> [!WARNING]
> ### `alejandra.toml` support is experimental!  
> [Alejandra](https://github.com/kamadorueda/alejandra), my formatter of choice, only added support for `alejandra.toml` in [v3.1.0](https://github.com/kamadorueda/alejandra/releases). All branches of nixpkgs are up-to-date (i.e., package v3.1.0 of alejandra) but your system's software repository may differ. You can run `alejandra --version` to be sure.